### PR TITLE
Small typo in signin.py

### DIFF
--- a/signin.py
+++ b/signin.py
@@ -134,7 +134,7 @@ def connect():
   # Store the access token in the session for later use.
   session['credentials'] = credentials
   session['gplus_id'] = gplus_id
-  response = make_response(json.dumps('Successfully connected user.', 200))
+  response = make_response(json.dumps('Successfully connected user.'), 200)
   response.headers['Content-Type'] = 'application/json'
   return response
 


### PR DESCRIPTION
Just a one character misplacement.  As you can see from the diff, I just moved a paren inward so that 200 is passed to `make_response` rather than `json.dumps`.
The second param of `json.dumps` is just a boolean that determines whether invalid data is skipped or throws an error when encoding.  From the `json.dumps` documentation (second param of `json.dumps` is called `skipkeys`:
```
If ``skipkeys`` is false then ``dict`` keys that are not basic types
    (``str``, ``unicode``, ``int``, ``long``, ``float``, ``bool``, ``None``)
    will be skipped instead of raising a ``TypeError``.
```
So that's why the app doesn't just crash because of this typo.